### PR TITLE
Use an mpsc channel to queue tagged lines

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,8 +33,9 @@
       "args": [
         "run",
         "--",
-        "printenv",
-        "AZURE_KEYVAULT_URL"
+        "cargo",
+        "run",
+        "--example=printenv"
       ],
       "cwd": "${workspaceFolder}",
       "envFile": ".azure/dev/.env"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,12 @@ futures = "0.3.31"
 prettytable-rs = "0.10.0"
 time = "0.3.37"
 timeago = "0.4.2"
-tokio = { version = "1.43.0", features = ["macros", "process", "rt"] }
+tokio = { version = "1.43.0", features = [
+    "io-std",
+    "macros",
+    "process",
+    "rt",
+] }
 tokio-util = { version = "0.7.13", features = ["codec"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }


### PR DESCRIPTION
May resolve #22, but in practice - with a slight delay between writes that we may more commonly see - what we have currently may be sufficient.

The `printenv` example writes incredibly fast. Even if we listen to reads and queue writes, without a delay it's not much better. It's at least in order and not jumbled, but its far from interleaved any better.
