### PR TITLE
Output color only for TTY

### DIFF
--- a/examples/printenv.rs
+++ b/examples/printenv.rs
@@ -42,8 +42,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let line = format!("{key}={value}");
         match i % 2 {
-            0 => println!("{stdout_prefix} {:>padding$}: {line}", i + 1),
-            _ => eprintln!("{stderr_prefix} {:>padding$}: {line}", i + 1),
+            0 => anstream::println!("{stdout_prefix} {:>padding$}: {line}", i + 1),
+            _ => anstream::eprintln!("{stderr_prefix} {:>padding$}: {line}", i + 1),
         }
     }
 


### PR DESCRIPTION
This does show there's a problem with `Stdio::piped()` in Rust, though. See #29 for details.
