### PR TITLE
Update Key Vault crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,8 @@ dependencies = [
  "async-lock",
  "async-stream",
  "async-trait",
- "azure_core",
+ "azure_core 0.26.0",
+ "azure_core 0.27.0",
  "azure_identity",
  "azure_security_keyvault_certificates",
  "azure_security_keyvault_keys",
@@ -212,8 +213,41 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "typespec",
- "typespec_client_core",
+ "typespec 0.6.0",
+ "typespec_client_core 0.5.0",
+]
+
+[[package]]
+name = "azure_core"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd9e026f749ac67e6d736ebcfa1ba36ab60ce3d6c446c67624a538f4e0667fa"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tracing",
+ "typespec 0.7.0",
+ "typespec_client_core 0.6.0",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06bce1a683e1a27013e64a1ff760700c7241275fe38787e578c3526f4ac569e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tracing",
+ "typespec_client_core 0.6.0",
 ]
 
 [[package]]
@@ -224,62 +258,62 @@ checksum = "eb5ecc1cd358f6aaff7f3fd3493c01d1bf3f7766675162f9764841089947a106"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_core",
+ "azure_core 0.26.0",
  "futures",
  "pin-project",
  "serde",
  "time",
  "tracing",
- "typespec_client_core",
+ "typespec_client_core 0.5.0",
  "url",
 ]
 
 [[package]]
 name = "azure_security_keyvault_certificates"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d70a371b0261c24bfb8e9427d881c7b5f4716a13c2715e53020faa70f9eb69e"
+checksum = "1b1998b4229fbe0c8071d4a36a80e7f7224de1f60e18767d9e12419b199803f7"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.27.0",
  "futures",
  "rustc_version",
  "serde",
  "serde_json",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 0.6.0",
 ]
 
 [[package]]
 name = "azure_security_keyvault_keys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3593efa99018cbefe556318a111f377d843e611fb7e3da52631b058cc54ccc7"
+checksum = "26034a9382f061f56e7c2a1a5a91ea4315b618992837e46a4487ebf8b934d6b5"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.27.0",
  "futures",
  "rustc_version",
  "serde",
  "serde_json",
- "typespec_client_core",
+ "typespec_client_core 0.6.0",
 ]
 
 [[package]]
 name = "azure_security_keyvault_secrets"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49189aad3bad78f409b84ce9f46f2b3cb56b99780702d4aed803bc22dcb88a0"
+checksum = "7ad61be32356d8dadd7553620dd65b0e63db6b2d89f56e1ca766e34081c125f3"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.27.0",
  "futures",
  "rustc_version",
  "serde",
  "serde_json",
  "time",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 0.6.0",
 ]
 
 [[package]]
@@ -289,9 +323,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b3c9bcf6dc1d6f4394634c4e2bc9b553342f4bf843fe51e8a7b64d90f05dcc4"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.26.0",
  "serde",
- "typespec_client_core",
+ "typespec_client_core 0.5.0",
  "url",
  "uuid",
 ]
@@ -2261,6 +2295,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typespec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2fffbed46125e0931e8f45618c3f6f0ffa2e0dc6d8b10a8de9f100b03138f33"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "typespec_client_core"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,8 +2327,34 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "typespec",
- "typespec_macros",
+ "typespec 0.6.0",
+ "typespec_macros 0.5.0",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96d81a432a1d2eb5cb3e9f813ff3811928e35f549bb5fa0a16abeffc66dec4c"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.3.3",
+ "pin-project",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec 0.7.0",
+ "typespec_macros 0.6.0",
  "url",
  "uuid",
 ]
@@ -2292,6 +2364,18 @@ name = "typespec_macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23800b88212e659cf2113cd5488510d0ead6ba26bf3b31158f77d47cec0d4031"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b032d7c2352fd8c2af91f942b914c52e315d3ea2b1bcad21a16cb94f72816bd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,12 @@ debug = ["azure_core/debug"]
 async-lock = "3.4.0"
 async-stream = "0.3.6"
 async-trait = "0.1.88"
-azure_core = "0.26.0"
+azure_core = "0.27.0"
+azure_core_26 = { package = "azure_core", version = "0.26.0" }
 azure_identity = "0.26.0"
-azure_security_keyvault_certificates = "0.4.0"
-azure_security_keyvault_keys = "0.5.0"
-azure_security_keyvault_secrets = "0.5.0"
+azure_security_keyvault_certificates = "0.5.0"
+azure_security_keyvault_keys = "0.6.0"
+azure_security_keyvault_secrets = "0.6.0"
 clap = { version = "4.5.28", features = ["derive", "env", "string"] }
 clap_complete = "4.5.46"
 dotazure = "0.2.0"

--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
 use akv_cli::{ErrorKind, ResultExt};
-use azure_core::credentials::Secret;
+use azure_core_26::credentials::Secret;
 use azure_identity::ClientSecretCredential;
 use azure_storage_blob::BlobServiceClient;
 use clap::{Parser, Subcommand};

--- a/src/bin/akv/commands/certificate.rs
+++ b/src/bin/akv/commands/certificate.rs
@@ -17,7 +17,7 @@ use azure_security_keyvault_certificates::{
         CreateCertificateParameters, IssuerParameters, KeyProperties,
         UpdateCertificatePropertiesParameters, X509CertificateProperties,
     },
-    CertificateClient, CertificateClientExt as _, ResourceExt as _, ResourceId,
+    CertificateClient, ResourceExt as _, ResourceId,
 };
 use clap::{ArgAction, Subcommand, ValueEnum};
 use futures::TryStreamExt as _;

--- a/src/bin/akv/main.rs
+++ b/src/bin/akv/main.rs
@@ -53,7 +53,12 @@ async fn main() -> Result<()> {
     #[cfg(debug_assertions)]
     if loaded_env {
         tracing::debug!("loaded environment variables from azd");
-        let _ = CREDENTIAL.set(AzureDeveloperCliCredential::new(None)? as Arc<dyn TokenCredential>);
+        let credential: Arc<dyn TokenCredential> = unsafe {
+            let credential: Arc<dyn azure_core_26::credentials::TokenCredential> =
+                AzureDeveloperCliCredential::new(None)?;
+            std::mem::transmute(credential)
+        };
+        let _ = CREDENTIAL.set(credential);
     }
 
     args.handle().await
@@ -80,6 +85,6 @@ static CREDENTIAL: OnceCell<Arc<dyn TokenCredential>> = OnceCell::new();
 
 pub(crate) fn credential() -> Result<Arc<dyn TokenCredential>> {
     CREDENTIAL
-        .get_or_try_init(|| Ok(DeveloperCredential::new(None)))
+        .get_or_try_init(|| Ok(DeveloperCredential::new(None).transmute()))
         .cloned()
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -67,12 +67,17 @@ impl TypeName for SecretClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use azure_core::credentials::TokenCredential;
     use azure_identity::DefaultAzureCredential;
     use azure_security_keyvault_secrets::SecretClient;
 
     #[tokio::test]
     async fn test_client_cache() {
-        let credential = DefaultAzureCredential::new().unwrap();
+        let credential: Arc<dyn TokenCredential> = unsafe {
+            let credential: Arc<dyn azure_core_26::credentials::TokenCredential> =
+                DefaultAzureCredential::new().unwrap();
+            std::mem::transmute(credential)
+        };
 
         let cache = ClientCache::<SecretClient>::new();
         cache

--- a/src/error.rs
+++ b/src/error.rs
@@ -180,6 +180,12 @@ impl From<azure_core::Error> for Error {
     }
 }
 
+impl From<azure_core_26::Error> for Error {
+    fn from(error: azure_core_26::Error) -> Self {
+        Self::new(ErrorKind::Other, error)
+    }
+}
+
 impl From<dotenvy::Error> for Error {
     fn from(error: dotenvy::Error) -> Self {
         Self::new(ErrorKind::Other, error)


### PR DESCRIPTION
Since `azure_identity` isn't updated yet, shows an example of how we can deal with different versions of `azure_core` IIF we have to implement or otherwise reference types therein as in this example of implementing and using `TokenCredential` across different versions of `azure_core`.
