### PR TITLE
Update workflow actions, secure environments

### DIFF
--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -31,6 +31,9 @@ env:
 jobs:
   bump-formula:
     runs-on: ubuntu-latest
+    environment:
+      name: homebrew
+      url: ${{ steps.bump.outputs.pullRequest }}
     steps:
     - name: Get user info
       id: user
@@ -38,15 +41,21 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
     - name: Run brew bump-formula-pr
+      id: bump
       # According to https://github.com/actions/runner-images?tab=readme-ov-file#available-images,
       # Linuxbrew is already installed on ubuntu-latest.
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         brew tap '${{ env.BREW_TAP }}'
-        brew bump-formula-pr --no-browse --url '${{ env.TARBALL_URL }}' '${{ env.BREW_TAP }}/${{ env.BREW_FORMULA }}'
+        pullRequest=$(brew bump-formula-pr --no-browse --url '${{ env.TARBALL_URL }}' '${{ env.BREW_TAP }}/${{ env.BREW_FORMULA }}' | tail -1)
+        echo "pullRequest=$pullRequest" >> "$GITHUB_OUTPUT"
       env:
         HOMEBREW_GIT_NAME: ${{ steps.user.outputs.name }}
         HOMEBREW_GIT_EMAIL: ${{ steps.user.outputs.email }}
         # https://github.com/settings/tokens/new?scopes=repo&description=Homebrew
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         TARBALL_URL: ${{ github.server_url }}/${{ github.repository }}/archive/${{ format('refs/tags/{0}', inputs.tag) || github.ref }}.tar.gz
+    - name: Summarize
+      run: |
+        echo "### Review formula update 👀" >> "$GITHUB_STEP_SUMMARY"
+        echo "${{ steps.bump.outputs.pullRequest }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         echo "name=akv${{ matrix.extension }}" | tee -a "$GITHUB_OUTPUT"
         echo "target=target/release/akv${{ matrix.extension }}" | tee -a "$GITHUB_OUTPUT"
     - name: Attest executable
-      uses: actions/attest-build-provenance@v2
+      uses: actions/attest-build-provenance@v4
       with:
         subject-path: ${{ steps.build.outputs.target }}
     - name: Package
@@ -104,7 +104,7 @@ jobs:
         "name=$name" >> $env:GITHUB_OUTPUT
         "target=$target" >> $env:GITHUB_OUTPUT
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.package.outputs.name }}
         path: ${{ steps.package.outputs.target }}
@@ -118,9 +118,9 @@ jobs:
     needs: package
     steps:
     - name: Download
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
     - name: Attest
-      uses: actions/attest-build-provenance@v2
+      uses: actions/attest-build-provenance@v4
       with:
         subject-path: ${{ github.workspace }}/*
 
@@ -128,6 +128,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: package
+    environment: crates-io
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -135,7 +136,7 @@ jobs:
       run: rustup install
     - name: Authenticate with crates.io
       id: auth
-      uses: rust-lang/crates-io-auth-action@v1
+      uses: rust-lang/crates-io-auth-action@v1.0.4
     - name: Publish
       run: cargo publish
       env:


### PR DESCRIPTION
Adds crates-io and homebrew environments to require manual review.
Moved the HOMEBREW_GITHUB_API_TOKEN to the homebrew enviornment as a fine-grained token with access only to heaths/homebrew-tap.
