### PR TITLE
Add --version flag, mutual exclusivity, and Read/Args tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "akv-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-lock",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akv-cli"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 description = """
 The Azure Key Vault CLI (unofficial) can read secrets from Key Vault,

--- a/src/bin/akv/commands/certificate.rs
+++ b/src/bin/akv/commands/certificate.rs
@@ -99,7 +99,7 @@ pub enum Commands {
     #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
     Edit {
         /// The certificate URL e.g., "https://my-vault.vault.azure.net/certificate/my-certificate".
-        #[arg(value_name = "URL")]
+        #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
         id: Option<Url>,
 
         /// The certificate name.
@@ -109,6 +109,10 @@ pub enum Commands {
         /// The vault URL e.g., "https://my-vault.vault.azure.net".
         #[arg(long, value_name = "URL", env = VAULT_ENV_NAME)]
         vault: Option<Url>,
+
+        /// Optional certificates version.
+        #[arg(long, requires = "name")]
+        version: Option<String>,
 
         #[command(flatten)]
         attributes: AttributeArgs,
@@ -183,7 +187,7 @@ pub enum Commands {
     #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
     Get {
         /// The certificate URL e.g., "https://my-vault.vault.azure.net/certificates/my-certificate".
-        #[arg(value_name = "URL")]
+        #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
         id: Option<Url>,
 
         /// The certificate name.
@@ -193,6 +197,10 @@ pub enum Commands {
         /// The vault URL e.g., "https://my-vault.vault.azure.net".
         #[arg(long, value_name = "URL", env = VAULT_ENV_NAME)]
         vault: Option<Url>,
+
+        /// Optional certificates version.
+        #[arg(long, requires = "name")]
+        version: Option<String>,
 
         /// Output format.
         #[arg(short = 'o', long, value_enum, default_value_t)]
@@ -369,6 +377,7 @@ impl Commands {
             id,
             vault,
             name,
+            version,
             attributes:
                 AttributeArgs {
                     enabled,
@@ -382,7 +391,8 @@ impl Commands {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), version.as_ref())?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);
@@ -443,7 +453,8 @@ impl Commands {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), None)?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);
@@ -508,13 +519,15 @@ impl Commands {
             id,
             name,
             vault,
+            version,
             output,
         } = self
         else {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), version.as_ref())?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);
@@ -546,7 +559,7 @@ impl Commands {
             panic!("Invalid command");
         };
 
-        let (vault, name, ..) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, ..) = super::select(id.as_ref(), vault.as_ref(), name.as_ref(), None)?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);
@@ -655,7 +668,8 @@ impl Commands {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), None)?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);

--- a/src/bin/akv/commands/encrypt.rs
+++ b/src/bin/akv/commands/encrypt.rs
@@ -27,7 +27,7 @@ pub struct Args {
     /// The key URL e.g., "https://my-vault.vault.azure.net/keys/my-key/version".
     ///
     /// The key URL must include a version.
-    #[arg(value_name = "URL")]
+    #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
     id: Option<Url>,
 
     /// The key name.

--- a/src/bin/akv/commands/key.rs
+++ b/src/bin/akv/commands/key.rs
@@ -73,7 +73,7 @@ pub enum Commands {
     #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
     Edit {
         /// The key URL e.g., "https://my-vault.vault.azure.net/keys/my-key".
-        #[arg(value_name = "URL")]
+        #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
         id: Option<Url>,
 
         /// The key name.
@@ -83,6 +83,10 @@ pub enum Commands {
         /// The vault URL e.g., "https://my-vault.vault.azure.net".
         #[arg(long, value_name = "URL", env = VAULT_ENV_NAME)]
         vault: Option<Url>,
+
+        /// Optional keys version.
+        #[arg(long, requires = "name")]
+        version: Option<String>,
 
         /// The operations permitted for this key.
         #[arg(long, value_enum, value_delimiter = ',')]
@@ -105,7 +109,7 @@ pub enum Commands {
     #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
     Get {
         /// The key URL e.g., "https://my-vault.vault.azure.net/keys/my-key".
-        #[arg(value_name = "URL")]
+        #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
         id: Option<Url>,
 
         /// The key name.
@@ -115,6 +119,10 @@ pub enum Commands {
         /// The vault URL e.g., "https://my-vault.vault.azure.net".
         #[arg(long, value_name = "URL", env = VAULT_ENV_NAME)]
         vault: Option<Url>,
+
+        /// Optional keys version.
+        #[arg(long, requires = "name")]
+        version: Option<String>,
 
         /// Output format.
         #[arg(short = 'o', long, value_enum, default_value_t)]
@@ -237,6 +245,7 @@ impl Commands {
             id,
             vault,
             name,
+            version,
             operations,
             attributes:
                 AttributeArgs {
@@ -251,7 +260,8 @@ impl Commands {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), version.as_ref())?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);
@@ -296,13 +306,15 @@ impl Commands {
             id,
             name,
             vault,
+            version,
             output,
         } = self
         else {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), version.as_ref())?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);
@@ -414,7 +426,8 @@ impl Commands {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), None)?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);

--- a/src/bin/akv/commands/mod.rs
+++ b/src/bin/akv/commands/mod.rs
@@ -159,6 +159,7 @@ fn select<'a>(
     id: Option<&Url>,
     vault: Option<&'a Url>,
     name: Option<&'a String>,
+    version: Option<&'a String>,
 ) -> akv_cli::Result<(Cow<'a, str>, Cow<'a, str>, Option<Cow<'a, str>>)> {
     match (id, vault, name) {
         (Some(id), _, None) => {
@@ -169,9 +170,11 @@ fn select<'a>(
                 resource.version.map(Cow::Owned),
             ))
         }
-        (None, Some(vault), Some(name)) => {
-            Ok((Cow::Borrowed(vault.as_str()), Cow::Borrowed(name), None))
-        }
+        (None, Some(vault), Some(name)) => Ok((
+            Cow::Borrowed(vault.as_str()),
+            Cow::Borrowed(name),
+            version.map(|v| Cow::Borrowed(v.as_str())),
+        )),
         _ => Err(akv_cli::Error::with_message(
             ErrorKind::InvalidData,
             "invalid arguments",

--- a/src/bin/akv/commands/read.rs
+++ b/src/bin/akv/commands/read.rs
@@ -18,7 +18,7 @@ use tracing::{Level, Span};
 #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
 pub struct Args {
     /// The secret URL e.g., "https://my-vault.vault.azure.net/secrets/my-secret".
-    #[arg(value_name = "URL")]
+    #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
     id: Option<Url>,
 
     /// The secret name.
@@ -28,6 +28,10 @@ pub struct Args {
     /// The vault URL e.g., "https://my-vault.vault.azure.net".
     #[arg(long, value_name = "URL", env = VAULT_ENV_NAME)]
     vault: Option<Url>,
+
+    /// Optional secrets version.
+    #[arg(long, requires = "name")]
+    version: Option<String>,
 
     /// Do not print a new line after the secret.
     #[arg(short = 'n', long)]
@@ -45,8 +49,12 @@ pub struct Args {
 impl Args {
     #[tracing::instrument(level = Level::INFO, skip(self), fields(vault, name, version), err)]
     pub async fn read(&self) -> Result<()> {
-        let (vault, name, version) =
-            super::select(self.id.as_ref(), self.vault.as_ref(), self.name.as_ref())?;
+        let (vault, name, version) = super::select(
+            self.id.as_ref(),
+            self.vault.as_ref(),
+            self.name.as_ref(),
+            self.version.as_ref(),
+        )?;
 
         let current = Span::current();
         current.record("vault", &*vault);

--- a/src/bin/akv/commands/secret.rs
+++ b/src/bin/akv/commands/secret.rs
@@ -61,7 +61,7 @@ pub enum Commands {
     #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
     Edit {
         /// The secret URL e.g., "https://my-vault.vault.azure.net/secrets/my-secret".
-        #[arg(value_name = "URL")]
+        #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
         id: Option<Url>,
 
         /// The secret name.
@@ -71,6 +71,10 @@ pub enum Commands {
         /// The vault URL e.g., "https://my-vault.vault.azure.net".
         #[arg(long, value_name = "URL", env = VAULT_ENV_NAME)]
         vault: Option<Url>,
+
+        /// Optional secrets version.
+        #[arg(long, requires = "name")]
+        version: Option<String>,
 
         /// The content type of the secret.
         #[arg(long)]
@@ -93,7 +97,7 @@ pub enum Commands {
     #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
     Get {
         /// The secret URL e.g., "https://my-vault.vault.azure.net/secrets/my-secret".
-        #[arg(value_name = "URL")]
+        #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
         id: Option<Url>,
 
         /// The secret name.
@@ -103,6 +107,10 @@ pub enum Commands {
         /// The vault URL e.g., "https://my-vault.vault.azure.net".
         #[arg(long, value_name = "URL", env = VAULT_ENV_NAME)]
         vault: Option<Url>,
+
+        /// Optional secrets version.
+        #[arg(long, requires = "name")]
+        version: Option<String>,
 
         /// Output format.
         #[arg(short = 'o', long, value_enum, default_value_t)]
@@ -219,6 +227,7 @@ impl Commands {
             id,
             vault,
             name,
+            version,
             content_type,
             attributes:
                 AttributeArgs {
@@ -233,7 +242,8 @@ impl Commands {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), version.as_ref())?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);
@@ -277,13 +287,15 @@ impl Commands {
             id,
             name,
             vault,
+            version,
             output,
         } = self
         else {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), version.as_ref())?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);
@@ -398,7 +410,8 @@ impl Commands {
             panic!("invalid command");
         };
 
-        let (vault, name, version) = super::select(id.as_ref(), vault.as_ref(), name.as_ref())?;
+        let (vault, name, version) =
+            super::select(id.as_ref(), vault.as_ref(), name.as_ref(), None)?;
         let current = Span::current();
         current.record("vault", &*vault);
         current.record("name", &*name);

--- a/tests/Certificates.Tests.ps1
+++ b/tests/Certificates.Tests.ps1
@@ -56,6 +56,25 @@ Describe 'Certificates' -Tag 'Certificates' {
         $script:certV1Url = $v1.id
     }
 
+    Context 'Args' -Tag 'Args' {
+        It 'rejects URL with --name' {
+            & $script:akv certificate get $script:certV1Url --name $script:certName 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects URL with --version' {
+            $version = $script:certV1Url.Split('/')[-1]
+            & $script:akv certificate get $script:certV1Url --version $version 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects --version without --name' {
+            $version = $script:certV1Url.Split('/')[-1]
+            & $script:akv certificate get --vault $script:AZURE_KEYVAULT_URL --version $version 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+    }
+
     Context 'Select by URL' -Tag 'URL' {
         It 'edits a certificate using URL form' {
             $result = & $script:akv certificate edit $script:certV1Url --tags env=test --output json | ConvertFrom-Json
@@ -97,6 +116,15 @@ Describe 'Certificates' -Tag 'Certificates' {
             $result.tags.env | Should -Be 'test'
         }
 
+        It 'edits a versioned certificate using --name and --version' {
+            $version = $script:certV1Url.Split('/')[-1]
+            $result = & $script:akv certificate edit --name $script:certName --vault $script:AZURE_KEYVAULT_URL --version $version --tags env=test --output json | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            $result.id | Should -Be $script:certV1Url
+            $result.tags | Should -Not -BeNullOrEmpty
+            $result.tags.env | Should -Be 'test'
+        }
+
         It 'lists versions using --name' {
             $versions = & $script:akv certificate list-versions --name $script:certName --vault $script:AZURE_KEYVAULT_URL --output json | ConvertFrom-Json
             $LASTEXITCODE | Should -Be 0
@@ -109,6 +137,14 @@ Describe 'Certificates' -Tag 'Certificates' {
             $result.id | Should -Match "/certificates/${script:certName}/"
             $result.tags | Should -Not -BeNullOrEmpty
             $result.tags.env | Should -Be 'test'
+        }
+
+        It 'gets a versioned certificate using --name and --version' {
+            $version = $script:certV1Url.Split('/')[-1]
+            $result = & $script:akv certificate get --name $script:certName --vault $script:AZURE_KEYVAULT_URL --version $version --output json | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            $result.id | Should -Be $script:certV1Url
+            $result.cer | Should -Not -BeNullOrEmpty
         }
     }
 }

--- a/tests/Encrypt.Tests.ps1
+++ b/tests/Encrypt.Tests.ps1
@@ -49,6 +49,25 @@ Describe 'Encrypt' -Tag 'Keys', 'Certificates' {
         $script:AZURE_KEYVAULT_URL = $script:AZURE_KEYVAULT_URL.TrimEnd('/')
     }
 
+    Context 'Args' -Tag 'Args' {
+        It 'rejects URL with --name' {
+            $keyUrl = "${script:AZURE_KEYVAULT_URL}/keys/my-key/1"
+            & $script:akv encrypt $keyUrl --name my-key --value test 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects URL with --version' {
+            $keyUrl = "${script:AZURE_KEYVAULT_URL}/keys/my-key/1"
+            & $script:akv encrypt $keyUrl --version 1 --value test 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects --version without --name' {
+            & $script:akv encrypt --vault $script:AZURE_KEYVAULT_URL --version 1 --value test 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+    }
+
     Context 'RSA key' -Tag 'Keys' {
         BeforeAll {
             # Create an RSA key and capture the versioned key URL.

--- a/tests/Keys.Tests.ps1
+++ b/tests/Keys.Tests.ps1
@@ -58,6 +58,25 @@ Describe 'Keys' -Tag 'Keys' {
         & $script:akv key create --name $script:keyName --vault $script:AZURE_KEYVAULT_URL --type rsa --size 2048 | Out-Null
     }
 
+    Context 'Args' -Tag 'Args' {
+        It 'rejects URL with --name' {
+            & $script:akv key get $script:keyV1Url --name $script:keyName 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects URL with --version' {
+            $version = $script:keyV1Url.Split('/')[-1]
+            & $script:akv key get $script:keyV1Url --version $version 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects --version without --name' {
+            $version = $script:keyV1Url.Split('/')[-1]
+            & $script:akv key get --vault $script:AZURE_KEYVAULT_URL --version $version 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+    }
+
     Context 'Select by URL' -Tag 'URL' {
         It 'edits a key using URL form' {
             $result = & $script:akv key edit $script:keyV1Url --tags env=test --output json | ConvertFrom-Json
@@ -92,6 +111,13 @@ Describe 'Keys' -Tag 'Keys' {
             $result.key.kid | Should -Match "/keys/${script:keyName}/"
         }
 
+        It 'edits a versioned key using --name and --version' {
+            $version = $script:keyV1Url.Split('/')[-1]
+            $result = & $script:akv key edit --name $script:keyName --vault $script:AZURE_KEYVAULT_URL --version $version --tags env=test --output json | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            $result.key.kid | Should -Be $script:keyV1Url
+        }
+
         It 'lists versions using --name' {
             $versions = & $script:akv key list-versions --name $script:keyName --vault $script:AZURE_KEYVAULT_URL --output json | ConvertFrom-Json
             $LASTEXITCODE | Should -Be 0
@@ -103,6 +129,13 @@ Describe 'Keys' -Tag 'Keys' {
             $LASTEXITCODE | Should -Be 0
             $result.key.kid | Should -Match "/keys/${script:keyName}/"
             $result.key.kid | Should -Not -Be $script:keyV1Url
+        }
+
+        It 'gets a versioned key using --name and --version' {
+            $version = $script:keyV1Url.Split('/')[-1]
+            $result = & $script:akv key get --name $script:keyName --vault $script:AZURE_KEYVAULT_URL --version $version --output json | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            $result.key.kid | Should -Be $script:keyV1Url
         }
     }
 }

--- a/tests/Read.Tests.ps1
+++ b/tests/Read.Tests.ps1
@@ -1,0 +1,109 @@
+# Copyright 2026 Heath Stewart.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+# Run with: Invoke-Pester tests/Read.Tests.ps1
+# Pass -Release to test a release build:
+#   $container = New-PesterContainer -Path ./tests/Read.Tests.ps1 -Data @{ Release = $true }
+#   $config = New-PesterConfiguration
+#   $config.Run.Container = $container
+#   Invoke-Pester -Configuration $config
+#
+# Requires a provisioned Key Vault via `azd up` or AZURE_KEYVAULT_URL set in the environment.
+
+param(
+    [switch] $Release
+)
+
+# cspell:ignore LASTEXITCODE
+Describe 'Read' -Tag 'Secrets' {
+    BeforeAll {
+        # Build the binary before running tests.
+        $repoRoot = Join-Path $PSScriptRoot '..' -Resolve
+        if ($Release) {
+            Write-Host 'Building release binary...'
+            cargo build --release 2>&1
+            $script:akv = Join-Path $repoRoot 'target' 'release' 'akv'
+        } else {
+            Write-Host 'Building debug binary...'
+            cargo build 2>&1
+            $script:akv = Join-Path $repoRoot 'target' 'debug' 'akv'
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "cargo build failed with exit code $LASTEXITCODE"
+        }
+
+        # Resolve AZURE_KEYVAULT_URL from the environment or via azd.
+        $script:AZURE_KEYVAULT_URL = if ($env:AZURE_KEYVAULT_URL) {
+            $env:AZURE_KEYVAULT_URL
+        } else {
+            azd env get-value AZURE_KEYVAULT_URL 2>$null
+        }
+
+        if (-not $script:AZURE_KEYVAULT_URL) {
+            throw "AZURE_KEYVAULT_URL is not set. Run 'azd up' to provision resources first."
+        }
+
+        $script:AZURE_KEYVAULT_URL = $script:AZURE_KEYVAULT_URL.TrimEnd('/')
+
+        $script:secretName = 'test-read-secret'
+
+        # Create first version and capture the versioned ID.
+        $v1 = & $script:akv secret create "${script:secretName}=version1" --vault $script:AZURE_KEYVAULT_URL --output json | ConvertFrom-Json
+        $script:secretV1Url = $v1.id
+
+        # Create second version by setting the same secret name with a new value.
+        & $script:akv secret create "${script:secretName}=version2" --vault $script:AZURE_KEYVAULT_URL | Out-Null
+    }
+
+    Context 'Args' -Tag 'Args' {
+        It 'rejects URL with --name' {
+            & $script:akv read $script:secretV1Url --name $script:secretName 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects URL with --version' {
+            $version = $script:secretV1Url.Split('/')[-1]
+            & $script:akv read $script:secretV1Url --version $version 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects --version without --name' {
+            $version = $script:secretV1Url.Split('/')[-1]
+            & $script:akv read --vault $script:AZURE_KEYVAULT_URL --version $version 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+    }
+
+    Context 'Select by URL' -Tag 'URL' {
+        It 'reads a versioned secret using URL form' {
+            $value = & $script:akv read $script:secretV1Url -n
+            $LASTEXITCODE | Should -Be 0
+            $value | Should -Be 'version1'
+        }
+
+        It 'reads the latest (versionless) secret using URL form' {
+            $versionlessUrl = "${script:AZURE_KEYVAULT_URL}/secrets/${script:secretName}"
+            $value = & $script:akv read $versionlessUrl -n
+            $LASTEXITCODE | Should -Be 0
+            $value | Should -Be 'version2'
+        }
+    }
+
+    Context 'Select by --name' -Tag 'Name' {
+        It 'reads the latest (versionless) secret using --name' {
+            $value = & $script:akv read --name $script:secretName --vault $script:AZURE_KEYVAULT_URL -n
+            $LASTEXITCODE | Should -Be 0
+            $value | Should -Be 'version2'
+        }
+
+        It 'reads a versioned secret using --name and --version' {
+            $version = $script:secretV1Url.Split('/')[-1]
+            $value = & $script:akv read --name $script:secretName --vault $script:AZURE_KEYVAULT_URL --version $version -n
+            $LASTEXITCODE | Should -Be 0
+            $value | Should -Be 'version1'
+        }
+    }
+}

--- a/tests/Secrets.Tests.ps1
+++ b/tests/Secrets.Tests.ps1
@@ -59,6 +59,25 @@ Describe 'Secrets' -Tag 'Secrets' {
         $script:secretV2Url = $v2.id
     }
 
+    Context 'Args' -Tag 'Args' {
+        It 'rejects URL with --name' {
+            & $script:akv secret get $script:secretV1Url --name $script:secretName 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects URL with --version' {
+            $version = $script:secretV1Url.Split('/')[-1]
+            & $script:akv secret get $script:secretV1Url --version $version 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+
+        It 'rejects --version without --name' {
+            $version = $script:secretV1Url.Split('/')[-1]
+            & $script:akv secret get --vault $script:AZURE_KEYVAULT_URL --version $version 2>$null
+            $LASTEXITCODE | Should -Be 2
+        }
+    }
+
     Context 'Select by URL' -Tag 'URL' {
         It 'edits a secret using URL form' {
             $result = & $script:akv secret edit $script:secretV1Url --tags env=test --output json | ConvertFrom-Json
@@ -99,6 +118,13 @@ Describe 'Secrets' -Tag 'Secrets' {
             $result.id | Should -Match "/secrets/${script:secretName}/"
         }
 
+        It 'edits a versioned secret using --name and --version' {
+            $version = $script:secretV1Url.Split('/')[-1]
+            $result = & $script:akv secret edit --name $script:secretName --vault $script:AZURE_KEYVAULT_URL --version $version --tags env=test --output json | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            $result.id | Should -Be $script:secretV1Url
+        }
+
         It 'lists versions using --name' {
             $versions = & $script:akv secret list-versions --name $script:secretName --vault $script:AZURE_KEYVAULT_URL --output json | ConvertFrom-Json
             $LASTEXITCODE | Should -Be 0
@@ -111,6 +137,13 @@ Describe 'Secrets' -Tag 'Secrets' {
             $LASTEXITCODE | Should -Be 0
             $result.id | Should -Match "/secrets/${script:secretName}/"
             $result.id | Should -Not -Be $script:secretV1Url
+        }
+
+        It 'gets a versioned secret using --name and --version' {
+            $version = $script:secretV1Url.Split('/')[-1]
+            $result = & $script:akv secret get --name $script:secretName --vault $script:AZURE_KEYVAULT_URL --version $version --output json | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            $result.id | Should -Be $script:secretV1Url
         }
 
         It 'reads the latest secret using --name' {


### PR DESCRIPTION
- Add optional --version to secret, key, certificate, read, and encrypt
  commands (requires --name; conflicts with positional URL)
- Update select() to thread version through the --name branch
- Add Context 'Args' tests (exit 2) to all test files
- Add tests/Read.Tests.ps1 with Args, URL, and --name contexts

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
