### PR TITLE
Replace openssl with aws-lc-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "async-lock",
  "async-stream",
  "async-trait",
+ "aws-lc-rs",
  "azure_core",
  "azure_identity",
  "azure_security_keyvault_certificates",
@@ -39,7 +40,6 @@ dependencies = [
  "futures",
  "indicatif",
  "libc",
- "openssl",
  "prettytable-rs",
  "reqwest",
  "serde",
@@ -200,6 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -802,7 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -853,21 +854,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1599,48 +1585,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking"
@@ -1697,12 +1645,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2039,7 +1981,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2130,7 +2072,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2754,6 +2696,12 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -2798,12 +2746,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,12 @@ color = ["clap/color", "colored_json", "yansi"]
 async-lock = "3.4.0"
 async-stream = "0.3.6"
 async-trait = "0.1.88"
-azure_core = { version = "0.35.0", default-features = false, features = [
-    "reqwest",
-    "reqwest_gzip",
-    "tokio",
-] } # Use reqwest default-tls (aws-lc-rs) instead of native-tls.
-azure_identity = { version = "0.35.0", default-features = false, features = [
-    "tokio",
-] }
-azure_security_keyvault_certificates = { version = "0.13.0", default-features = false }
-azure_security_keyvault_keys = { version = "0.14.0", default-features = false }
-azure_security_keyvault_secrets = { version = "0.14.0", default-features = false }
+aws-lc-rs = "1.16.3"
+azure_core = "0.35.0"
+azure_identity = { version = "0.35.0", features = ["tokio"] }
+azure_security_keyvault_certificates = "0.13.0"
+azure_security_keyvault_keys = "0.14.0"
+azure_security_keyvault_secrets = "0.14.0"
 clap = { version = "4.5.28", default-features = false, features = [
     "derive",
     "env",
@@ -48,7 +43,6 @@ dotenvy = "0.15.7"
 futures = "0.3.31"
 indicatif = "0.18.0"
 libc = "0.2.171"
-openssl = "0.10.72" # Continue to use openssl for JOSE: https://github.com/aws/aws-lc-rs/issues/617
 prettytable-rs = "0.10.0"
 reqwest = "0.13.2"
 serde = { version = "1.0.219", features = ["derive"] }
@@ -75,9 +69,7 @@ yansi = { version = "1.0.1", features = [
 
 [dev-dependencies]
 async-trait = "0.1.88"
-azure_storage_blob = { version = "0.12.0", default-features = false, features = [
-    "tokio",
-] }
+azure_storage_blob = "0.12.0"
 criterion = "0.6.0"
 wildcard = "0.3.0"
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -16,6 +16,7 @@ hooks:
     interactive: true
     shell: pwsh
     run: |
-      az storage blob upload -c 'examples' -n 'main.bicep' --content-type 'text/plain' -f 'infra/main.bicep' --overwrite
-      az storage blob upload -c 'examples' -n 'main.bicepparam' --content-type 'text/plain' -f 'infra/main.bicepparam' --overwrite
-      az storage blob upload -c 'examples' -n 'resources.bicep' --content-type 'text/plain' -f 'infra/resources.bicep' --overwrite
+      Write-Host "Uploading infra/* files to 'examples' container"
+      az storage blob upload -c 'examples' -n 'main.bicep' --content-type 'text/plain' -f 'infra/main.bicep' --overwrite | Out-Null
+      az storage blob upload -c 'examples' -n 'main.parameters.json' --content-type 'text/plain' -f 'infra/main.parameters.json' --overwrite | Out-Null
+      az storage blob upload -c 'examples' -n 'resources.bicep' --content-type 'text/plain' -f 'infra/resources.bicep' --overwrite | Out-Null

--- a/examples/setup.ps1
+++ b/examples/setup.ps1
@@ -5,5 +5,5 @@ $AZURE_KEYVAULT_URL = (azd env get-value AZURE_KEYVAULT_URL).TrimEnd('/')
 $AZURE_KEYVAULT_DEK_URL = azd env get-value AZURE_KEYVAULT_DEK_URL
 $env:X_SECRET_1 = "$AZURE_KEYVAULT_URL/secrets/secret-1"
 $env:X_SECRET_2 = "$AZURE_KEYVAULT_URL/secrets/secret-2"
-$env:X_JWE = cargo run -- encrypt "$AZURE_KEYVAULT_DEK_URL" 'Hello, world!'
+$env:X_JWE = cargo run -- encrypt "$AZURE_KEYVAULT_DEK_URL" --value 'Hello, world!'
 $env:X_JWE_BIN = (Get-Random -Count 32).ForEach({ [BitConverter]::GetBytes($_) }) | cargo run -- encrypt "$AZURE_KEYVAULT_DEK_URL" --in-file '-'

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -5,5 +5,5 @@ AZURE_KEYVAULT_URL="$(azd env get-value AZURE_KEYVAULT_URL)"
 AZURE_KEYVAULT_DEK_URL="$(azd env get-value AZURE_KEYVAULT_DEK_URL)"
 export X_SECRET_1="${AZURE_KEYVAULT_URL%/}/secrets/secret-1"
 export X_SECRET_2="${AZURE_KEYVAULT_URL%/}/secrets/secret-2"
-export X_JWE=$(cargo run -- encrypt "${AZURE_KEYVAULT_DEK_URL}" 'Hello, world!')
+export X_JWE=$(cargo run -- encrypt "${AZURE_KEYVAULT_DEK_URL}" --value 'Hello, world!')
 export X_JWE_BIN=$(dd if=/dev/random bs=4 count=32 2>/dev/null | cargo run -- encrypt "${AZURE_KEYVAULT_DEK_URL}" --in-file '-')

--- a/src/error.rs
+++ b/src/error.rs
@@ -200,8 +200,8 @@ impl From<dotenvy::Error> for Error {
     }
 }
 
-impl From<openssl::error::ErrorStack> for Error {
-    fn from(error: openssl::error::ErrorStack) -> Self {
+impl From<aws_lc_rs::error::Unspecified> for Error {
+    fn from(error: aws_lc_rs::error::Unspecified) -> Self {
         Self::new(ErrorKind::Other, error)
     }
 }

--- a/src/jose/jwe.rs
+++ b/src/jose/jwe.rs
@@ -7,12 +7,9 @@ use crate::{
     jose::{Algorithm, Encode, EncryptionAlgorithm, Header, Set, Type, Unset},
     Error, ErrorKind, Result, ResultExt as _,
 };
+use aws_lc_rs::{aead, rand};
 use azure_core::{base64, Bytes};
 use azure_security_keyvault_keys::models::KeyOperationResult;
-use openssl::{
-    rand,
-    symm::{self, Cipher},
-};
 use std::{marker::PhantomData, str::FromStr};
 
 /// A JSON Web Encryption (JWE) structure.
@@ -55,18 +52,26 @@ impl Jwe {
             .enc
             .as_ref()
             .ok_or_else(|| Error::with_message(ErrorKind::InvalidData, "expected enc"))?;
-        let cipher: Cipher = enc.try_into()?;
+        let alg: &'static aead::Algorithm = enc.try_into()?;
         let aad = self.header.encode()?;
 
-        let plaintext: Bytes = symm::decrypt_aead(
-            cipher,
-            &result.cek,
-            Some(&self.iv),
-            aad.as_bytes(),
-            &self.ciphertext,
-            &self.tag,
-        )?
-        .into();
+        // `LessSafeKey` is used instead of `OpeningKey` + `NonceSequence` because decryption
+        // must supply an arbitrary nonce stored in the JWE compact form. The nonce-sequence
+        // APIs expect to own nonce tracking and cannot accept an externally supplied nonce
+        // without extra scaffolding.
+        let key = aead::LessSafeKey::new(
+            aead::UnboundKey::new(alg, &result.cek)
+                .map_err(|_| Error::with_message(ErrorKind::InvalidData, "invalid CEK"))?,
+        );
+        let nonce = aead::Nonce::try_assume_unique_for_key(&self.iv)
+            .map_err(|_| Error::with_message(ErrorKind::InvalidData, "invalid IV"))?;
+        // aws-lc-rs expects ciphertext || tag concatenated in a single buffer.
+        let mut buf = self.ciphertext.to_vec();
+        buf.extend_from_slice(&self.tag);
+        let plaintext = key
+            .open_in_place(nonce, aead::Aad::from(aad.as_bytes()), &mut buf)
+            .map_err(|_| Error::with_message(ErrorKind::Other, "decryption failed"))?;
+        let plaintext = Bytes::copy_from_slice(plaintext);
 
         Ok(plaintext)
     }
@@ -251,7 +256,7 @@ impl JweEncryptor<Set, Set> {
     {
         // Determine how big the CEK should be.
         let enc = &self.enc.unwrap_or(EncryptionAlgorithm::A128GCM);
-        let cipher: Cipher = enc.try_into()?;
+        let cipher: &'static aead::Algorithm = enc.try_into()?;
 
         // Validate or generate the CEK.
         let cek = match self.cek {
@@ -268,7 +273,7 @@ impl JweEncryptor<Set, Set> {
             None => {
                 // Allocate enough space for largest supported cipher.
                 let mut buf = [0; 32];
-                rand::rand_bytes(&mut buf)?;
+                rand::fill(&mut buf)?;
                 Bytes::copy_from_slice(&buf[0..cipher.key_len()])
             }
         };
@@ -290,46 +295,50 @@ impl JweEncryptor<Set, Set> {
         };
         let aad = header.encode()?;
 
-        // Generate the IV.
-        let iv_len = cipher.iv_len().ok_or_else(|| {
-            Error::with_message(
-                ErrorKind::InvalidData,
-                format!("expected iv length for cipher {}", &enc),
-            )
-        })?;
+        // All AES-GCM modes in aws-lc-rs use a fixed 96-bit (12-byte) nonce (aead::NONCE_LEN).
         let iv = match self.iv {
-            Some(v) if v.len() == iv_len => v,
+            Some(v) if v.len() == aead::NONCE_LEN => v,
             Some(v) => {
                 return Err(Error::with_message_fn(ErrorKind::InvalidData, || {
-                    format!("require iv size of {} bytes, got {}", iv_len, v.len())
+                    format!(
+                        "require iv size of {} bytes, got {}",
+                        aead::NONCE_LEN,
+                        v.len()
+                    )
                 }));
             }
             None => {
-                // Allocate enough space for largest supported cipher.
-                let mut buf = [0; 12];
-                rand::rand_bytes(&mut buf)?;
-                Bytes::copy_from_slice(&buf[0..iv_len])
+                let mut buf = [0u8; aead::NONCE_LEN];
+                rand::fill(&mut buf)?;
+                Bytes::copy_from_slice(&buf)
             }
         };
 
+        // `LessSafeKey` is used instead of `SealingKey` + `NonceSequence` because the IV is
+        // stored in the JWE compact form and must be reproduced verbatim for decryption. The
+        // nonce-sequence APIs own nonce generation and do not expose a way to supply an
+        // arbitrary nonce without extra scaffolding.
+        let key = aead::LessSafeKey::new(
+            aead::UnboundKey::new(cipher, &cek)
+                .map_err(|_| Error::with_message(ErrorKind::InvalidData, "invalid CEK"))?,
+        );
+        let nonce = aead::Nonce::try_assume_unique_for_key(&iv)
+            .map_err(|_| Error::with_message(ErrorKind::InvalidData, "invalid IV"))?;
         let plaintext = self.plaintext.expect("expected plaintext");
-        let mut tag = [0; 16];
-        let ciphertext: Bytes = symm::encrypt_aead(
-            cipher,
-            &cek,
-            Some(&iv),
-            aad.as_bytes(),
-            &plaintext,
-            &mut tag,
-        )?
-        .into();
+        // aws-lc-rs appends the authentication tag to the ciphertext buffer in-place.
+        let mut buf = plaintext.to_vec();
+        key.seal_in_place_append_tag(nonce, aead::Aad::from(aad.as_bytes()), &mut buf)
+            .map_err(|_| Error::with_message(ErrorKind::Other, "encryption failed"))?;
+        // Split the appended tag (last tag_len bytes) from the ciphertext.
+        let tag = buf.split_off(buf.len() - cipher.tag_len());
+        let ciphertext: Bytes = buf.into();
 
         Ok(Jwe {
             header,
             cek: result.cek,
             iv,
             ciphertext,
-            tag: Bytes::copy_from_slice(&tag),
+            tag: tag.into(),
         })
     }
 }
@@ -348,20 +357,20 @@ impl<C, K> Default for JweEncryptor<C, K> {
     }
 }
 
-impl TryFrom<EncryptionAlgorithm> for Cipher {
+impl TryFrom<EncryptionAlgorithm> for &'static aead::Algorithm {
     type Error = Error;
     fn try_from(value: EncryptionAlgorithm) -> Result<Self> {
         (&value).try_into()
     }
 }
 
-impl TryFrom<&EncryptionAlgorithm> for Cipher {
+impl TryFrom<&EncryptionAlgorithm> for &'static aead::Algorithm {
     type Error = Error;
-    fn try_from(value: &EncryptionAlgorithm) -> Result<Cipher> {
+    fn try_from(value: &EncryptionAlgorithm) -> Result<&'static aead::Algorithm> {
         match value {
-            EncryptionAlgorithm::A128GCM => Ok(Cipher::aes_128_gcm()),
-            EncryptionAlgorithm::A192GCM => Ok(Cipher::aes_192_gcm()),
-            EncryptionAlgorithm::A256GCM => Ok(Cipher::aes_256_gcm()),
+            EncryptionAlgorithm::A128GCM => Ok(&aead::AES_128_GCM),
+            EncryptionAlgorithm::A192GCM => Ok(&aead::AES_192_GCM),
+            EncryptionAlgorithm::A256GCM => Ok(&aead::AES_256_GCM),
             EncryptionAlgorithm::Other(value) => {
                 Err(Error::with_message_fn(ErrorKind::InvalidData, || {
                     format!("unsupported encryption algorithm {value}")
@@ -523,22 +532,22 @@ mod tests {
 
     #[test]
     fn encryption_algorithm_cipher() {
-        let cipher: Cipher = EncryptionAlgorithm::A128GCM
+        let cipher: &'static aead::Algorithm = EncryptionAlgorithm::A128GCM
             .try_into()
             .expect("try_into should succeed");
-        assert_eq!(cipher.iv_len(), Some(12));
+        assert_eq!(cipher.nonce_len(), 12);
         assert_eq!(cipher.key_len(), 16);
 
-        let cipher: Cipher = EncryptionAlgorithm::A192GCM
+        let cipher: &'static aead::Algorithm = EncryptionAlgorithm::A192GCM
             .try_into()
             .expect("try_into should succeed");
-        assert_eq!(cipher.iv_len(), Some(12));
+        assert_eq!(cipher.nonce_len(), 12);
         assert_eq!(cipher.key_len(), 24);
 
-        let cipher: Cipher = EncryptionAlgorithm::A256GCM
+        let cipher: &'static aead::Algorithm = EncryptionAlgorithm::A256GCM
             .try_into()
             .expect("try_into should succeed");
-        assert_eq!(cipher.iv_len(), Some(12));
+        assert_eq!(cipher.nonce_len(), 12);
         assert_eq!(cipher.key_len(), 32);
     }
 


### PR DESCRIPTION
Since azure_core now uses aws-lc-rs by default and that supports AES GCM, we can use that for JWE and drop openssl entirely for a slightly smaller binary and an easier build.

Co-authored-by: Copilot <copilot@github.com>
