### PR TITLE
Analyze help commands for consistency

### DIFF
--- a/.agents/skills/analyze-help/SKILL.md
+++ b/.agents/skills/analyze-help/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: analyze-help
+description: Run when CLI commands or arguments change. Analyze commands and arguments for consistent patterns.
+---
+
+# Analyze Help
+
+Analyze generated CLI help for **unexpected** inconsistencies only. Accepted differences below should **not** be flagged unless behavior or docs drift beyond these rules.
+
+Generate help from clap:
+
+```bash
+RUSTFLAGS='--cfg help_markdown' cargo run -- help-markdown
+```
+
+- Analyze stdout directly; do not save generated help into this repo just for review
+- Ignore utility commands: `completion`, `help-markdown`
+
+## General commands
+
+- Group: `inject`, `run`, `read`, `encrypt`, `decrypt`
+- `run` is process/env oriented and does not need the same selector or file flags as the others
+- `decrypt` may differ from `encrypt` because key selection comes from the JWE `kid`
+- `inject` may differ from `read` because it transforms templates rather than reading one named secret
+
+## Management commands
+
+- Group: `secret`, `key`, `certificate`
+- Shared resource-targeting pattern should stay consistent where applicable:
+  - full resource URL
+  - or `--name <NAME>` + `--vault <URL>` + optional `--version <VERSION>`
+- `secret create` using positional `NAME=VALUE` is acceptable
+- `create` commands may otherwise differ by resource-specific properties
+- Certificate policy commands are valid exceptions:
+  - `edit-policy`, `get-policy`
+  - may differ from other certificate commands because policy is distinct from certificate version retrieval
+- Certificate commands may have additional options beyond secret/key
+
+## Flag only
+
+- New selector mismatches within a command group
+- New required/optional argument mismatches for equivalent operations
+- New naming drift for equivalent parameters
+- New doc/example path errors, especially resource URL shapes

--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,7 @@
     "rust-toolchain.toml"
   ],
   "words": [
+    "cfgs",
     "ciphertext",
     "clippy",
     "cooldown",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Use these skills when applicable. Read the skill file for full instructions.
 
 | Skill              | File                                         | When to use                           |
 | ------------------ | -------------------------------------------- | ------------------------------------- |
+| analyze-help       | `.agents/skills/analyze-help/SKILL.md`       | When CLI commands or arguments change |
 | check-spelling     | `.agents/skills/check-spelling/SKILL.md`     | Checking or fixing spelling errors    |
 | lint-markdown      | `.agents/skills/lint-markdown/SKILL.md`      | Linting or fixing markdown formatting |
 | pin-github-actions | `.agents/skills/pin-github-actions/SKILL.md` | Pin GitHub Actions to a commit SHA    |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,14 @@ Now you can run the `blobs` example within the `akv run` command:
 cargo run -- run -- cargo run --example blobs
 ```
 
+## Help
+
+To view all help options, you can print all subcommands and arguments as markdown:
+
+```bash
+RUSTFLAGS='--cfg help_markdown' cargo run -- help-markdown
+```
+
 ## Troubleshooting
 
 To help troubleshoot issues, you can trace information to the terminal:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "azure_security_keyvault_secrets",
  "azure_storage_blob",
  "clap",
+ "clap-markdown",
  "clap_complete",
  "colored_json",
  "criterion",
@@ -452,6 +453,15 @@ checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-markdown"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a2617956a06d4885b490697b5307ebb09fec10b088afc18c81762d848c2339"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ yansi = { version = "1.0.1", features = [
     "detect-tty",
 ], optional = true }
 
+[target.'cfg(help_markdown)'.dependencies]
+clap-markdown = "0.1.5"
+
 [dev-dependencies]
 async-trait = "0.1.88"
 azure_storage_blob = "1.0.0"
@@ -83,6 +86,12 @@ wildcard = "0.3.0"
 opt-level = "s"
 panic = "abort"
 strip = "debuginfo"
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    "cfg(help_markdown)",
+]
 
 [lints.rustdoc]
 bare_urls = "allow"

--- a/src/bin/akv/commands/certificate.rs
+++ b/src/bin/akv/commands/certificate.rs
@@ -98,7 +98,7 @@ pub enum Commands {
     /// Edits a certificate in an Azure Key Vault.
     #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
     Edit {
-        /// The certificate URL e.g., "https://my-vault.vault.azure.net/certificate/my-certificate".
+        /// The certificate URL e.g., "https://my-vault.vault.azure.net/certificates/my-certificate".
         #[arg(value_name = "URL", conflicts_with_all = ["name", "version"])]
         id: Option<Url>,
 
@@ -130,7 +130,7 @@ pub enum Commands {
     /// Edits the certificate policy for the next certificate request.
     #[command(group(ArgGroup::new("ident").args(&["id", "name"]).required(true)))]
     EditPolicy {
-        /// The certificate URL e.g., "https://my-vault.vault.azure.net/certificate/my-certificate".
+        /// The certificate URL e.g., "https://my-vault.vault.azure.net/certificates/my-certificate".
         #[arg(value_name = "URL")]
         id: Option<Url>,
 

--- a/src/bin/akv/commands/mod.rs
+++ b/src/bin/akv/commands/mod.rs
@@ -58,6 +58,10 @@ pub enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
+
+    /// Print help as markdown.
+    #[cfg(help_markdown)]
+    HelpMarkdown,
 }
 
 impl Commands {
@@ -75,6 +79,11 @@ impl Commands {
                 let mut cmd = super::Args::command();
                 let bin_name = cmd.get_name().to_string();
                 generate(*shell, &mut cmd, bin_name, &mut io::stdout());
+                Ok(())
+            }
+            #[cfg(help_markdown)]
+            Commands::HelpMarkdown => {
+                clap_markdown::print_help_markdown::<super::Args>();
                 Ok(())
             }
         }

--- a/src/bin/akv/main.rs
+++ b/src/bin/akv/main.rs
@@ -38,6 +38,13 @@ async fn main() {
     };
 
     let args = Args::parse();
+    #[cfg(help_markdown)]
+    {
+        if args.help_markdown {
+            clap_markdown::print_help_markdown::<Args>();
+            return;
+        }
+    }
     style = args.color_mode().style();
     if let Err(err) = run(loaded_dotenv, args).await {
         eprintln!("{}: {err:#}", style.error("Error"));
@@ -100,6 +107,11 @@ struct Args {
     /// Log verbose messages. Pass `-vv` to log more verbosely.
     #[arg(global = true, short = 'v', long, action = clap::ArgAction::Count)]
     verbose: u8,
+
+    /// Print help as markdown.
+    #[cfg(help_markdown)]
+    #[arg(global = true, long, hide = true)]
+    help_markdown: bool,
 }
 
 impl Args {


### PR DESCRIPTION
Adds a custom configuration named `help_markdown` and agent skill to analyze
commands and arguments for consistency, documenting acceptable differences.
